### PR TITLE
Replace xxhash with maphash

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/oittaa/ptp4u
 go 1.24
 
 require (
-	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/goccy/go-yaml v1.18.0
 	golang.org/x/sys v0.34.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
-github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/goccy/go-yaml v1.18.0 h1:8W7wMFS12Pcas7KU+VVkaiCng+kG8QiFeFwzFb+rwuw=
 github.com/goccy/go-yaml v1.18.0/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 golang.org/x/sys v0.34.0 h1:H5Y5sJ2L2JRdyv7ROF1he/lPdvFsd0mJHFw2ThKHxLA=

--- a/main.go
+++ b/main.go
@@ -100,6 +100,16 @@ func main() {
 		os.Exit(1)
 	}
 
+	if c.RecvWorkers <= 0 {
+		slog.Error("Number of receive workers must be greater than zero.", "recvworkers", c.RecvWorkers)
+		os.Exit(1)
+	}
+
+	if c.SendWorkers <= 0 {
+		slog.Error("Number of send workers must be greater than zero.", "workers", c.SendWorkers)
+		os.Exit(1)
+	}
+
 	switch c.TimestampType {
 	case timestamp.SW:
 		slog.Warn("Software timestamps greatly reduce the precision")

--- a/timestamp/timestamp_linux.go
+++ b/timestamp/timestamp_linux.go
@@ -107,6 +107,8 @@ func ioctlHWTimestampCaps(fd int, ifname string) (int32, int32, error) {
 
 	if hw.Rx_filters&(1<<unix.HWTSTAMP_FILTER_PTP_V2_L4_EVENT) > 0 {
 		rxFilter = unix.HWTSTAMP_FILTER_PTP_V2_L4_EVENT
+	} else if hw.Rx_filters&(1<<unix.HWTSTAMP_FILTER_PTP_V2_EVENT) > 0 {
+		rxFilter = unix.HWTSTAMP_FILTER_PTP_V2_EVENT
 	} else if hw.Rx_filters&(1<<unix.HWTSTAMP_FILTER_ALL) > 0 {
 		rxFilter = unix.HWTSTAMP_FILTER_ALL
 	}


### PR DESCRIPTION
There's a performance hit, but the source data is in a better format compared to the previous simple addition.

```go
package main

import (
	"context"
	"encoding/binary"
	"hash/maphash"
	"sync"
	"testing"
	"unsafe"

	"github.com/cespare/xxhash"
	ptp "github.com/facebook/time/ptp/protocol"
	"github.com/facebook/time/ptp/ptp4u/drain"
	"github.com/facebook/time/ptp/ptp4u/server"
	"github.com/facebook/time/ptp/ptp4u/stats"
	"github.com/facebook/time/timestamp"
)

type Server struct {
	Config *server.Config
	Stats  stats.Stats
	Checks []drain.Drain
	sw     []*sendWorker

	// server source fds
	eFd int
	gFd int

	// drain logic
	cancel context.CancelFunc
	ctx    context.Context
}

type sendWorker struct {
	mux            sync.Mutex
	id             int
	queue          chan *server.SubscriptionClient
	signalingQueue chan *server.SubscriptionClient
	config         *server.Config
	stats          stats.Stats

	clients map[ptp.MessageType]map[ptp.PortIdentity]*server.SubscriptionClient
}

var seed = maphash.MakeSeed()
var clipi1 = ptp.PortIdentity{
	PortNumber:    1,
	ClockIdentity: ptp.ClockIdentity(1234),
}

func newSendWorker(i int, c *server.Config, st stats.Stats) *sendWorker {
	s := &sendWorker{
		id:     i,
		config: c,
		stats:  st,
	}
	s.clients = make(map[ptp.MessageType]map[ptp.PortIdentity]*server.SubscriptionClient)
	s.queue = make(chan *server.SubscriptionClient, c.QueueSize)
	s.signalingQueue = make(chan *server.SubscriptionClient, c.QueueSize)
	return s
}

func getServer() Server {
	c := &server.Config{
		StaticConfig: server.StaticConfig{
			TimestampType: timestamp.SW,
			SendWorkers:   100,
		},
	}
	s := Server{
		Config: c,
		Stats:  stats.NewJSONStats(),
		sw:     make([]*sendWorker, c.SendWorkers),
	}

	for i := 0; i < s.Config.SendWorkers; i++ {
		s.sw[i] = newSendWorker(i, c, s.Stats)
	}
	return s
}

func (s *Server) findWorkerOriginal(clientID ptp.PortIdentity, offset int64) *sendWorker {
	val := int64(clientID.ClockIdentity) + int64(clientID.PortNumber) + offset
	hashableBytes := unsafe.Slice((*byte)(unsafe.Pointer(&val)), 8)
	hash := xxhash.Sum64(hashableBytes)
	return s.sw[hash%uint64(s.Config.SendWorkers)]
}

func (s *Server) findWorkerSlice(clientID ptp.PortIdentity, offset int64) *sendWorker {
	var b [18]byte
	binary.LittleEndian.PutUint64(b[0:8], uint64(clientID.ClockIdentity))
	binary.LittleEndian.PutUint16(b[8:10], uint16(clientID.PortNumber))
	binary.LittleEndian.PutUint64(b[10:18], uint64(offset))
	hash := xxhash.Sum64(b[:])
	return s.sw[hash%uint64(s.Config.SendWorkers)]
}

func (s *Server) findWorkerMaphashUnsafe(clientID ptp.PortIdentity, offset int64) *sendWorker {
	val := int64(clientID.ClockIdentity) + int64(clientID.PortNumber) + offset
	hashableBytes := unsafe.Slice((*byte)(unsafe.Pointer(&val)), 8)
	hash := maphash.Bytes(seed, hashableBytes)
	return s.sw[hash%uint64(len(s.sw))]
}

func (s *Server) findWorkerMaphashSlice(clientID ptp.PortIdentity, offset int64) *sendWorker {
	var b [18]byte
	binary.LittleEndian.PutUint64(b[0:8], uint64(clientID.ClockIdentity))
	binary.LittleEndian.PutUint16(b[8:10], uint16(clientID.PortNumber))
	binary.LittleEndian.PutUint64(b[10:18], uint64(offset))
	hash := maphash.Bytes(seed, b[:])
	return s.sw[hash%uint64(len(s.sw))]
}

func BenchmarkFindWorkerOriginal(b *testing.B) {
	s := getServer()

	for n := 0; n < b.N; n++ {
		_ = s.findWorkerOriginal(clipi1, 0)
	}
}

func BenchmarkFindWorkerSlice(b *testing.B) {
	s := getServer()

	for n := 0; n < b.N; n++ {
		_ = s.findWorkerSlice(clipi1, 0)
	}
}

func BenchmarkFindWorkerMaphashUnsafe(b *testing.B) {
	s := getServer()

	for n := 0; n < b.N; n++ {
		_ = s.findWorkerMaphashUnsafe(clipi1, 0)
	}
}

func BenchmarkFindWorkerMaphashSlice(b *testing.B) {
	s := getServer()

	for n := 0; n < b.N; n++ {
		_ = s.findWorkerMaphashSlice(clipi1, 0)
	}
}
```

```
$ go test -bench=BenchmarkFind -benchmem
goos: linux
goarch: amd64
pkg: hash-bench
cpu: AMD Ryzen 7 9800X3D 8-Core Processor
BenchmarkFindWorkerOriginal-16          370288154                3.230 ns/op           0 B/op          0 allocs/op
BenchmarkFindWorkerSlice-16             80133555                14.27 ns/op            0 B/op          0 allocs/op
BenchmarkFindWorkerMaphashUnsafe-16     93032774                11.16 ns/op            0 B/op          0 allocs/op
BenchmarkFindWorkerMaphashSlice-16      99618212                11.40 ns/op            0 B/op          0 allocs/op
PASS
ok      hash-bench      4.890s

```